### PR TITLE
Add `dnsbeEppException` and add `getAwaitingVerification` function to `dnsbeEppInfoDomainResponse` [EXO-530]

### DIFF
--- a/Protocols/EPP/eppExtensions/dnsbe-1.0/eppExceptions/dnsbeEppException.php
+++ b/Protocols/EPP/eppExtensions/dnsbe-1.0/eppExceptions/dnsbeEppException.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Metaregistrar\EPP;
+
+use Exception;
+
+/**
+* <epp xmlns="urn:ietf:params:xml:ns:epp-1.0" xmlns:dnsbe="http://www.dns.be/xml/epp/dnsbe-1.0">
+*   <response>
+*     <result code="2005">
+*       <msg>Parameter value syntax error</msg>
+*     </result>
+*     <extension>
+*       <dnsbe:ext>
+*         <dnsbe:result>
+*           <dnsbe:msg>missing glue for ns.test-domain-1.be</dnsbe:msg>
+*         </dnsbe:result>
+*       </dnsbe:ext>
+*     </extension>
+*     <trID>
+*       <clTRID>client-00018</clTRID>
+*       <svTRID>dnsbe-113</svTRID>
+*     </trID>
+*   </response>
+* </epp>
+*/
+/**
+ * Class dnsbeEppException.
+ */
+class dnsbeEppException extends eppException
+{
+    /**
+     * @var eppResponse
+     */
+    private $eppresponse;
+
+    public function __construct($message = '', $code = 0, ?Exception $previous = null, $reason = null, $command = null)
+    {
+        if ($command) {
+            $this->eppresponse = new eppResponse();
+            $this->eppresponse->loadXML($command);
+        }
+        parent::__construct($message, $code, $previous, $reason, $command);
+    }
+
+    public function getDnsbeErrorMessage()
+    {
+        return $this->eppresponse->queryPath('/epp:epp/epp:response/epp:extension/dnsbe:ext/dnsbe:result/dnsbe:msg');
+    }
+}

--- a/Protocols/EPP/eppExtensions/dnsbe-1.0/eppResponses/dnsbeEppInfoDomainResponse.php
+++ b/Protocols/EPP/eppExtensions/dnsbe-1.0/eppResponses/dnsbeEppInfoDomainResponse.php
@@ -80,5 +80,27 @@ class dnsbeEppInfoDomainResponse extends eppInfoDomainResponse {
             return null;
         }
     }
+
+    /**
+     * Retrieve a boolean flag if this domain name is awaiting verification or not.
+     *
+     * @return bool
+     */
+    public function getAwaitingVerification()
+    {
+        $xpath = $this->xPath();
+        $result = $xpath->query('/epp:epp/epp:response/epp:extension/dnsbe:ext/dnsbe:infData/dnsbe:domain/dnsbe:nameserversOverridden');
+
+        $nameserversOveridden = $result->item(0)?->nodeValue;
+
+        // If the nameservers are not overridden, the domain is not awaiting verification.
+        if (!$nameserversOveridden) {
+            return false;
+        }
+
+        $reason = $result->item(0)?->attributes?->item(0)?->value;
+
+        return $nameserversOveridden === 'true' && $reason === 'Pending registrant verification';
+    }
 }
 

--- a/Protocols/EPP/eppExtensions/dnsbe-1.0/includes.php
+++ b/Protocols/EPP/eppExtensions/dnsbe-1.0/includes.php
@@ -52,3 +52,6 @@ $this->addCommandResponse('Metaregistrar\EPP\dnsbeEppCheckDomainRequest', 'Metar
 include_once(dirname(__FILE__) . '/eppRequests/dnsbeEppUpdateDomainRequest.php');
 include_once(dirname(__FILE__) . '/eppResponses/dnsbeEppUpdateDomainResponse.php');
 $this->addCommandResponse('Metaregistrar\EPP\dnsbeEppUpdateDomainRequest', 'Metaregistrar\EPP\dnsbeEppUpdateDomainResponse');
+
+include_once(dirname(__FILE__) . '/eppExceptions/dnsbeEppException.php');
+$this->addException('Metaregistrar\EPP\dnsbeEppException');


### PR DESCRIPTION
## What does it do?
- Add `dnsbeEppException` to be able to get the correct error message.
- Add `getAwaitingVerification` function to `dnsbeEppInfoDomainResponse`.

## How to test?
- Cause an exception, catch it and use the `getDnsbeErrorMessage` to get the error message.
- Call the `getAwaitingVerification` function on a `dnsbeEppInfoDomainResponse`.

## Issues
[EXO-530](https://www.notion.so/exonet/Implementeer-DNSBE-registrar-15298cb660f380289079c8a2f593253e?pvs=25)

