### PR TITLE
Add option to cancel the auth code using the authInfo-1.1 extension [EXO-531]

### DIFF
--- a/Protocols/EPP/eppExtensions/authInfo-1.1/eppRequests/authEppInfoDomainRequest.php
+++ b/Protocols/EPP/eppExtensions/authInfo-1.1/eppRequests/authEppInfoDomainRequest.php
@@ -19,19 +19,27 @@ namespace Metaregistrar\EPP;
 
 */
 class authEppInfoDomainRequest extends eppInfoDomainRequest {
-    function __construct($infodomain, $hosts = null, $withAuthcode = false) {
+    function __construct($infodomain, $hosts = null, $withAuthcode = false, $cancelAuthCode = false) {
         parent::__construct($infodomain, $hosts);
-        if($withAuthcode == true) {
-            $this->addAuthExtension();
+
+        if ($withAuthcode && $cancelAuthCode) {
+            throw new eppException('Cannot request and cancel authcode at the same time');
         }
+
+        if ($withAuthcode) {
+            $this->addAuthExtension('authInfo:request');
+        } elseif ($cancelAuthCode) {
+            $this->addAuthExtension('authInfo:cancel');
+        }
+      
         $this->addSessionId();
     }
 
 
-    public function addAuthExtension() {
+    public function addAuthExtension(string $method) {
         $authext = $this->createElement('authInfo:info');
         $authext->setAttribute('xmlns:authInfo', 'http://www.eurid.eu/xml/epp/authInfo-1.1');
-        $authext->appendChild($this->createElement('authInfo:request'));
+        $authext->appendChild($this->createElement($method));
         $this->getExtension()->appendChild($authext);
     }
 


### PR DESCRIPTION
## What does it do?
Add option to cancel the auth code using the authInfo-1.1 extension.

## How to test?
- Use the `authEppInfoDomainRequest` to cancel the auth code of a domain.

## Issues
[EXO-531](https://www.notion.so/exonet/Implementeer-EURid-registrar-15298cb660f3804bb7bdf98de5a226cb?pvs=25)