### PR TITLE
ci: add upstream-sync workflow (auto-PR, manual squash-merge)

### DIFF
--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -1,0 +1,80 @@
+---
+# Opens a PR that brings changes from the upstream metaregistrar/php-epp-client
+# into this fork, keeping the local Exonet patches. Merge the PR manually with
+# "Squash and merge" to land the upstream changes as a single *Verified* commit
+# (GitHub web-flow signature) on master.
+name: Upstream sync
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'   # Mondays 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  UPSTREAM: metaregistrar/php-epp-client
+  UPSTREAM_BRANCH: master
+
+jobs:
+  upstream-sync:
+    name: Open upstream sync PR
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      # App token so the branch/PR are created as the app (and the PR triggers
+      # CI). Needs the app installed on this repo with contents: write +
+      # pull-requests: write.
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+
+      - name: Checkout fork
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 0
+
+      - name: Open an upstream sync PR
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+
+          git remote add upstream "https://github.com/${UPSTREAM}.git"
+          git fetch --no-tags --quiet upstream "${UPSTREAM_BRANCH}"
+
+          upstream_sha="$(git rev-parse --short "upstream/${UPSTREAM_BRANCH}")"
+          branch="upstream-sync/${upstream_sha}"
+
+          # Dedupe on the upstream SHA: a squash-merge doesn't make upstream an
+          # ancestor of master, so we can't detect "already synced" via ancestry.
+          # Instead, skip if a PR for this exact upstream commit already exists
+          # (open or already merged/closed).
+          if [ -n "$(gh pr list --head "${branch}" --state all --json number --jq '.[].number' | head -n1)" ]; then
+            echo "Already synced/attempted ${UPSTREAM}@${upstream_sha}; nothing to do."
+            exit 0
+          fi
+
+          # Mirror upstream onto a feature branch. Its commits stay unsigned there
+          # (feature branches have no signing requirement); a "Squash and merge"
+          # produces the single signed commit that lands on master.
+          git push --force origin "upstream/${UPSTREAM_BRANCH}:refs/heads/${branch}"
+
+          body="Automated sync of upstream [\`${UPSTREAM}\`](https://github.com/${UPSTREAM}) into this fork. Merge with **Squash and merge** to land the upstream changes as a single Verified commit on \`master\`; the local Exonet patches are preserved. Resolve any conflicts with the patches first. Upstream: ${UPSTREAM}@${upstream_sha}."
+
+          if ! url="$(gh pr create --base master --head "${branch}" \
+              --title "Sync with upstream ${UPSTREAM}@${upstream_sha}" \
+              --body "${body}")"; then
+            echo "No PR created (fork already contains these changes); cleaning up branch."
+            git push origin --delete "${branch}" || true
+            exit 0
+          fi
+          echo "Opened ${url} — review and merge it manually with \"Squash and merge\"."


### PR DESCRIPTION
Adds a scheduled **Upstream sync** workflow that keeps this fork current with `metaregistrar/php-epp-client`, while preserving the local Exonet patches (dnsbe/auth-code).

### How it works
Weekly (Mondays 06:00 UTC) + `workflow_dispatch`:
1. Mints a **`RELEASE_APP_*`** app token (app is installed on this repo, with Contents + Pull requests: write).
2. Fetches upstream and dedupes on the upstream SHA (one PR per upstream commit).
3. Mirrors `upstream/master` onto an `upstream-sync/<sha>` branch and opens a PR → `master`.

That's all the action does — **you merge the PR manually**.

### Merging
Use **"Squash and merge"** → the upstream changes land as a **single Verified commit** on `master` (GitHub web-flow signature); the local patches are preserved. Resolve any conflicts with the patches first.

> Choose **Squash and merge** deliberately, not a regular merge commit: only squash keeps it to one signed commit — a merge commit would pull in upstream's unsigned commits.

### Why squash
Upstream's commits aren't ours and can't be re-signed without rewriting them. Squashing each sync into one commit satisfies "signed commits" unconditionally (also under a future "all commits verified" ruleset). Trade-offs: upstream's granular history isn't kept in the fork (the code is identical), and each sync's PR diff shows from the old merge-base — squash-merge does a 3-way merge so only the net new changes apply; patch conflicts are resolved per sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
