### PR TITLE
fix(upstream-sync): create the sync PR in the fork

### DIFF
--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -56,9 +56,9 @@ jobs:
 
           # Dedupe on the upstream SHA: a squash-merge doesn't make upstream an
           # ancestor of master, so we can't detect "already synced" via ancestry.
-          # Instead, skip if a PR for this exact upstream commit already exists
-          # (open or already merged/closed).
-          if [ -n "$(gh pr list --head "${branch}" --state all --json number --jq '.[].number' | head -n1)" ]; then
+          # Skip if a PR for this exact upstream commit already exists (any state).
+          # -R pins THIS fork, since gh resolves fork context to the upstream parent.
+          if [ -n "$(gh pr list -R "${GITHUB_REPOSITORY}" --head "${branch}" --state all --json number --jq '.[].number' | head -n1)" ]; then
             echo "Already synced/attempted ${UPSTREAM}@${upstream_sha}; nothing to do."
             exit 0
           fi
@@ -70,11 +70,13 @@ jobs:
 
           body="Automated sync of upstream [\`${UPSTREAM}\`](https://github.com/${UPSTREAM}) into this fork. Merge with **Squash and merge** to land the upstream changes as a single Verified commit on \`master\`; the local Exonet patches are preserved. Resolve any conflicts with the patches first. Upstream: ${UPSTREAM}@${upstream_sha}."
 
-          if ! url="$(gh pr create --base master --head "${branch}" \
-              --title "Sync with upstream ${UPSTREAM}@${upstream_sha}" \
-              --body "${body}")"; then
-            echo "No PR created (fork already contains these changes); cleaning up branch."
-            git push origin --delete "${branch}" || true
-            exit 0
-          fi
+          # Create the PR in THIS fork. `gh pr create` defaults the base repo to the
+          # upstream parent for forks (which the app token can't touch -> "Resource
+          # not accessible by integration"), so hit the fork's pulls API directly.
+          url="$(gh api --method POST "repos/${GITHUB_REPOSITORY}/pulls" \
+            -f "title=Sync with upstream ${UPSTREAM}@${upstream_sha}" \
+            -f "head=${branch}" \
+            -f "base=master" \
+            -f "body=${body}" \
+            --jq '.html_url')"
           echo "Opened ${url} — review and merge it manually with \"Squash and merge\"."


### PR DESCRIPTION
The first `Upstream sync` run pushed the `upstream-sync/<sha>` branch fine but failed at PR creation with **`Resource not accessible by integration (createPullRequest)`**.

**Cause:** `gh pr create` defaults the base repo to the **upstream parent** (`metaregistrar/php-epp-client`) for forks — the app token has no access there. And the old `if ! ...` fallback masked it as "fork already contains changes" and deleted the branch.

**Fix:** create the PR against **this fork's** `pulls` API (`gh api repos/${GITHUB_REPOSITORY}/pulls`), pin `gh pr list` to the fork with `-R`, and let real errors surface (no masking, no branch deletion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)